### PR TITLE
Publish jsdoc on tag

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -88,3 +88,41 @@ jobs:
         run: npm publish --access public
     env:
       NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+
+  publish-doc:
+
+    needs:
+      - node-unit-tests
+      - browser-unit-tests
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src
+      - name: Build jsdoc
+        working-directory: ./src
+        run: |
+          npm ci
+          grunt jsdoc
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Checkout gh-pages
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Update gh-pages branch
+        run: |
+          rm -rf gh-pages/${{ steps.get_version.outputs.VERSION }}
+          mv src/dist/docs "gh-pages/${{ steps.get_version.outputs.VERSION }}"
+          cd gh-pages
+          ln -sfn "${{ steps.get_version.outputs.VERSION }}" latest
+          ln -sfn "${{ steps.get_version.outputs.VERSION }}" stable
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add "${{ steps.get_version.outputs.VERSION }}" latest stable
+          git push

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
             library: {
                 src: ['NGSI.js', 'README.md'],
                 options: {
-                    destination: 'dist/docs/library',
+                    destination: 'dist/docs',
                     configure: '.jsdocrc'
                 }
             }


### PR DESCRIPTION
This PR makes Github Action able to publish jsdoc on tag creation removing the need of doing so by hand in each release.