### PR TITLE
Manage disconnect events of eventsources

### DIFF
--- a/NGSI.js
+++ b/NGSI.js
@@ -1343,19 +1343,20 @@
                 priv.promise = null;
                 priv.connection_id = data.id;
 
-                priv.source.removeEventListener('error', handle_connection_rejected, true);
-                priv.source.removeEventListener('init', wait_event_source_init, true);
-                priv.source.addEventListener('error', function (e) {
-                    priv.connected = false;
-                    priv.source = null;
-                    priv.connection_id = null;
-                    var oldCallbacks = priv.callbacks;
-                    priv.callbacks = {};
-                    priv.callbacksBySubscriptionId = {};
-
-                    for (var key in oldCallbacks) {
-                        oldCallbacks[key].method(null, null, true);
+                priv.source.removeEventListener("error", handle_connection_rejected, true);
+                priv.source.removeEventListener("init", wait_event_source_init, true);
+                priv.source.addEventListener("error", (e) => {
+                    const callbacks = priv.callbacks;
+                    if (e.target.readyState === e.target.CLOSED) {
+                        priv.connected = false;
+                        priv.source = null;
+                        priv.connection_id = null;
+                        priv.callbacks = {};
+                        priv.callbacksBySubscriptionId = {};
                     }
+                    callbacks.forEach((callback) => {
+                        callback.method(null, null, true, e.target.readyState === e.target.CLOSED ? "closed" : "disconnected");
+                    });
                 }, true);
                 priv.source.addEventListener('notification', function (e) {
                     var data = JSON.parse(e.data);

--- a/NGSI.js
+++ b/NGSI.js
@@ -1345,6 +1345,11 @@
 
                 priv.source.removeEventListener("error", handle_connection_rejected, true);
                 priv.source.removeEventListener("init", wait_event_source_init, true);
+                priv.source.addEventListener("open", () => {
+                    priv.callbacks.forEach((callback) => {
+                        callback.method(null, null, true, "open");
+                    });
+                }, true);
                 priv.source.addEventListener("error", (e) => {
                     const callbacks = priv.callbacks;
                     if (e.target.readyState === e.target.CLOSED) {

--- a/NGSI.js
+++ b/NGSI.js
@@ -1346,18 +1346,22 @@
                 priv.source.removeEventListener("error", handle_connection_rejected, true);
                 priv.source.removeEventListener("init", wait_event_source_init, true);
                 priv.source.addEventListener("open", () => {
-                    priv.callbacks.forEach((callback) => {
-                        callback.method(null, null, true, "open");
+                    priv.promise = null;
+                    Object.values(priv.callbacks).forEach((callback) => {
+                        callback.method(null, null, true, "connected");
                     });
                 }, true);
                 priv.source.addEventListener("error", (e) => {
-                    const callbacks = priv.callbacks;
+                    const callbacks = Object.values(priv.callbacks);
                     if (e.target.readyState === e.target.CLOSED) {
-                        priv.connected = false;
+                        priv.promise = null;
                         priv.source = null;
                         priv.connection_id = null;
                         priv.callbacks = {};
                         priv.callbacksBySubscriptionId = {};
+                    } else {
+                        // Use a resolved promise to mark this connection as connecting
+                        priv.promise = Promise.resolve();
                     }
                     callbacks.forEach((callback) => {
                         callback.method(null, null, true, e.target.readyState === e.target.CLOSED ? "closed" : "disconnected");
@@ -1365,7 +1369,7 @@
                 }, true);
                 priv.source.addEventListener('notification', function (e) {
                     var data = JSON.parse(e.data);
-                    priv.callbacks[data.callback_id].method(data.payload, data.headers);
+                    priv.callbacks[data.callback_id].method(data.payload, data.headers, false, null);
                 }, true);
 
                 resolve();
@@ -1450,7 +1454,6 @@
         privates.set(this, {
             callbacks: {},
             callbacksBySubscriptionId: {},
-            connected: false,
             connection_id: null,
             promise: null,
             source: null
@@ -2729,7 +2732,7 @@
      *     null,
      *     [{type: 'ONCHANGE', condValues: ['position']}],
      *     {
-     *         onNotify: function (data) {
+     *         onNotify: function (data, error, statechange, newstate) {
      *             // called when a notification arrives
      *         },
      *         onSuccess: function (data) {
@@ -2762,10 +2765,12 @@
         var url = new URL(NGSI.endpoints.v1.SUBSCRIBE_CONTEXT, this.url);
         if (typeof options.onNotify === 'function' && this.ngsi_proxy != null) {
 
-            var onNotify = function onNotify(payload) {
-                var doc = JSON.parse(payload);
-                var data = NGSI.parseNotifyContextRequest(doc, options);
-                options.onNotify(data);
+            const onNotify = (payload, headers, statechange, newstate) => {
+                if (payload != null) {
+                    payload = JSON.parse(payload);
+                    payload = NGSI.parseNotifyContextRequest(payload, options);
+                }
+                options.onNotify(payload, headers, statechange, newstate);
             };
 
             this.ngsi_proxy.requestCallback(onNotify).then(function (proxy_callback) {
@@ -5050,15 +5055,17 @@
      *        }
      *    },
      *    "notification": {
-     *        "callback": function (notification, headers, error) {
+     *        "callback": (notification, headers, statechange, newstate) => {
      *            // notification.attrsformat provides information about the format used by notification.data
      *            // notification.data contains the modified entities
      *            // notification.subscriptionId provides the associated subscription id
      *            // etc...
      *
-     *            // In case of disconnection from the ngsi-proxy, this method
-     *            // will be called with error = true and notification and
-     *            // header being null
+     *            // In case of state change, statechange will be true and
+     *            // newstate will provide details about the new state.
+     *            // Supported states are: disconnected, connected and closed.
+     *            // notification and header parameters will be null if
+     *            // statechange is true
      *        },
      *        "attrs": [
      *            "temperature",
@@ -5096,11 +5103,14 @@
                 throw new TypeError('invalid callback configuration');
             }
 
-            var onNotify = function onNotify(payload, headers) {
-                var notification = JSON.parse(payload);
-                notification.attrsformat = headers['ngsiv2-attrsformat'];
-                this(notification);
-            }.bind(subscription.notification.callback);
+            const callback = subscription.notification.callback;
+            const onNotify = (payload, headers, statechange, newstate) => {
+                if (payload != null) {
+                    payload = JSON.parse(payload);
+                    payload.attrsformat = headers['ngsiv2-attrsformat'];
+                }
+                callback(payload, headers, statechange, newstate);
+            };
 
             p = connection.ngsi_proxy.requestCallback(onNotify).then(
                 function (response) {
@@ -6834,15 +6844,17 @@
      *         "attributes": ["speed"],
      *         "format": "keyValues",
      *         "endpoint": {
-     *             "callback": (notification, headers, error) => {
+     *             "callback": (notification, headers, statechange, newstate) => {
      *                 // notification.attrsformat provides information about the format used by notification.data
      *                 // notification.data contains the modified entities
      *                 // notification.subscriptionId provides the associated subscription id
      *                 // etc...
      *
-     *                 // In case of disconnection from the ngsi-proxy, this method
-     *                 // will be called with error = true (the notification and
-     *                 // the header parameters will contain a null value)
+     *                 // In case of state change, statechange will be true and
+     *                 // newstate will provide details about the new state.
+     *                 // Supported states are: disconnected, connected and closed.
+     *                 // notification and header parameters will be null if
+     *                 // statechange is true
      *             },
      *             "accept": "application/json"
      *         }
@@ -6899,11 +6911,13 @@
 
             const callback = subscription.notification.endpoint.callback;
             const format = subscription.notification.format || "normalized";
-            const onNotify = (payload, headers) => {
-                const notification = JSON.parse(payload);
-                notification.format = format;
-                notification.contentType = headers['content-type'];
-                callback(notification);
+            const onNotify = (payload, headers, statechange, newstate) => {
+                if (payload != null) {
+                    payload = JSON.parse(payload);
+                    payload.format = format;
+                    payload.contentType = headers["content-type"];
+                }
+                callback(payload, headers, statechange, newstate);
             };
 
             p = connection.ngsi_proxy.requestCallback(onNotify).then(

--- a/tests/common/ldSpec.js
+++ b/tests/common/ldSpec.js
@@ -1515,17 +1515,26 @@ if ((typeof require === 'function') && typeof global != null) {
                             }),
                             {
                                 "content-type": "application/json"
-                            }
+                            },
+                            false,
+                            null
                         );
-                        expect(listener).toHaveBeenCalledWith({
-                            format: "normalized",
-                            contentType: "application/json",
-                            id: "urn:ngsi-ld:Notification:1",
-                            type: "Notification",
-                            subscriptionId: "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c",
-                            notifiedAt: "2020-06-11T12:34:00+02:00",
-                            data: notification_data
-                        });
+                        expect(listener).toHaveBeenCalledWith(
+                            {
+                                format: "normalized",
+                                contentType: "application/json",
+                                id: "urn:ngsi-ld:Notification:1",
+                                type: "Notification",
+                                subscriptionId: "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c",
+                                notifiedAt: "2020-06-11T12:34:00+02:00",
+                                data: notification_data
+                            },
+                            {
+                                "content-type": "application/json"
+                            },
+                            false,
+                            null
+                        );
                     },
                     (e) => {
                         fail("Failure callback called");

--- a/tests/common/ldSpec.js
+++ b/tests/common/ldSpec.js
@@ -1472,12 +1472,10 @@ if ((typeof require === 'function') && typeof global != null) {
 
                 // Mock ngsi proxy responses
                 connection.ngsi_proxy = {
-                    requestCallback: jasmine.createSpy("requestCallback").and.callFake(function () {
-                        return Promise.resolve({
-                            callback_id: "1",
-                            url: "http://ngsiproxy.example.com/callback/1"
-                        });
-                    }),
+                    requestCallback: jasmine.createSpy("requestCallback").and.returnValue(Promise.resolve({
+                        callback_id: "1",
+                        url: "http://ngsiproxy.example.com/callback/1"
+                    })),
                     associateSubscriptionId: jasmine.createSpy("associateSubscriptionId"),
                     closeCallback: jasmine.createSpy("closeCallback")
                 };
@@ -1494,52 +1492,104 @@ if ((typeof require === 'function') && typeof global != null) {
                     }
                 });
 
-                connection.ld.createSubscription(subscription).then(
-                    (result) => {
-                        expect(result).toEqual({
-                            subscription: subscription,
-                            location: "/ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c"
-                        });
+                connection.ld.createSubscription(subscription).then((result) => {
+                    expect(result).toEqual({
+                        subscription: subscription,
+                        location: "/ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c"
+                    });
 
-                        expect(connection.ngsi_proxy.requestCallback)
-                            .toHaveBeenCalledWith(jasmine.any(Function));
-                        expect(connection.ngsi_proxy.associateSubscriptionId)
-                            .toHaveBeenCalledWith("1", "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c", "ld");
-                        connection.ngsi_proxy.requestCallback.calls.argsFor(0)[0](
-                            JSON.stringify({
-                                id: "urn:ngsi-ld:Notification:1",
-                                type: "Notification",
-                                subscriptionId: "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c",
-                                notifiedAt: "2020-06-11T12:34:00+02:00",
-                                data: notification_data
-                            }),
-                            {
-                                "content-type": "application/json"
-                            },
-                            false,
-                            null
-                        );
-                        expect(listener).toHaveBeenCalledWith(
-                            {
-                                format: "normalized",
-                                contentType: "application/json",
-                                id: "urn:ngsi-ld:Notification:1",
-                                type: "Notification",
-                                subscriptionId: "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c",
-                                notifiedAt: "2020-06-11T12:34:00+02:00",
-                                data: notification_data
-                            },
-                            {
-                                "content-type": "application/json"
-                            },
-                            false,
-                            null
-                        );
+                    expect(connection.ngsi_proxy.requestCallback)
+                        .toHaveBeenCalledWith(jasmine.any(Function));
+                    expect(connection.ngsi_proxy.associateSubscriptionId)
+                        .toHaveBeenCalledWith("1", "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c", "ld");
+                    connection.ngsi_proxy.requestCallback.calls.argsFor(0)[0](
+                        JSON.stringify({
+                            id: "urn:ngsi-ld:Notification:1",
+                            type: "Notification",
+                            subscriptionId: "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c",
+                            notifiedAt: "2020-06-11T12:34:00+02:00",
+                            data: notification_data
+                        }),
+                        {
+                            "content-type": "application/json"
+                        },
+                        false,
+                        null
+                    );
+                    expect(listener).toHaveBeenCalledWith(
+                        {
+                            format: "normalized",
+                            contentType: "application/json",
+                            id: "urn:ngsi-ld:Notification:1",
+                            type: "Notification",
+                            subscriptionId: "urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c",
+                            notifiedAt: "2020-06-11T12:34:00+02:00",
+                            data: notification_data
+                        },
+                        {
+                            "content-type": "application/json"
+                        },
+                        false,
+                        null
+                    );
+                }).catch(fail).finally(done);
+            });
+
+            it("handles disconnect events when using ngsi-proxy callbacks", (done) => {
+                const listener = jasmine.createSpy("listener");
+                const subscription = {
+                    "type": "Subscription",
+                    "entities": [
+                        {
+                            "idPattern": ".*",
+                            "type": "Vehicle"
+                        }
+                    ],
+                    "notification": {
+                        "endpoint": {
+                            "callback": listener,
+                            "attributes": [
+                                "speed",
+                                "location"
+                            ]
+                        }
                     },
-                    (e) => {
-                        fail("Failure callback called");
+                    "expires": "2016-04-05T14:00:00.00Z",
+                    "@context": "https://schema.lab.fiware.org/ld/context"
+                };
+
+                // Mock ngsi proxy responses
+                connection.ngsi_proxy = {
+                    requestCallback: jasmine.createSpy("requestCallback").and.returnValue(Promise.resolve({
+                        callback_id: "1",
+                        url: "http://ngsiproxy.example.com/callback/1"
+                    })),
+                    associateSubscriptionId: jasmine.createSpy("associateSubscriptionId"),
+                    closeCallback: jasmine.createSpy("closeCallback")
+                };
+
+                ajaxMockup.addStaticURL("http://ngsi.server.com/ngsi-ld/v1/subscriptions", {
+                    method: "POST",
+                    status: 201,
+                    headers: {
+                        'Location': '/ngsi-ld/v1/subscriptions/urn:ngsi-ld:Subscription:5ee0a80950053da73775b62c'
                     }
-                ).finally(done);
+                });
+
+                connection.ld.createSubscription(subscription).then((result) => {
+                    connection.ngsi_proxy.requestCallback.calls.argsFor(0)[0](
+                        null,
+                        null,
+                        true,
+                        "disconnected"
+                    );
+                    expect(listener).toHaveBeenCalledWith(
+                        null,
+                        null,
+                        true,
+                        "disconnected"
+                    );
+                }).catch(fail).finally(done);
             });
 
             describe("handles connection errors:", () => {

--- a/tests/common/v2Spec.js
+++ b/tests/common/v2Spec.js
@@ -1385,13 +1385,21 @@ if ((typeof require === 'function') && typeof global != null) {
                         }),
                         {
                             "ngsiv2-attrsformat": "normalized"
-                        }
+                        },
+                        false,
+                        null
                     );
-                    expect(listener).toHaveBeenCalledWith({
-                        attrsformat: "normalized",
-                        data: notification_data,
-                        subscriptionId: "abcde98765"
-                    });
+                    expect(listener).toHaveBeenCalledWith(
+                        {
+                            attrsformat: "normalized",
+                            data: notification_data,
+                            subscriptionId: "abcde98765"
+                        }, {
+                            "ngsiv2-attrsformat": "normalized"
+                        },
+                        false,
+                        null
+                    );
 
                     done();
                 }, function (e) {

--- a/tests/helpers/EventSourceMock.js
+++ b/tests/helpers/EventSourceMock.js
@@ -9,6 +9,7 @@
 
         EventSource.mockedeventsources.push(this);
         this.events = {
+            open: [],
             error: [],
             init: [],
             close: [],
@@ -16,14 +17,9 @@
         };
 
         if (EventSource.eventsourceconfs[url] !== "timeout") {
-            var timeout = setTimeout(() => {
-                var i;
-                var event = !EventSource.eventsourceconfs[url] ? this.events.init : this.events.error;
-                for (i = 0; i < event.length; i++) {
-                    try {
-                        event[i]({data: "{\"id\": 1}"});
-                    } catch (e) {}
-                }
+            const timeout = setTimeout(() => {
+                const event = !EventSource.eventsourceconfs[url] ? "init" : "error";
+                this.dispatchEvent(event, event === "init" ? {data: "{\"id\": 1}"} : null);
             }, 0);
             EventSource.timeouts.push(timeout);
         }
@@ -36,6 +32,17 @@
         EventSource.timeouts = [];
         EventSource.mockedeventsources = [];
         EventSource.eventsourceconfs = {};
+    };
+
+    EventSource.prototype.CONNECTING = 0;
+    EventSource.prototype.OPEN = 1;
+    EventSource.prototype.CLOSED = 2;
+    EventSource.prototype.dispatchEvent = function dispatchEvent(event, data) {
+        this.events[event].forEach((listener) => {
+            try {
+                listener(data);
+            } catch (e) {}
+        });
     };
 
     EventSource.prototype.addEventListener = function addEventListener(event_name, handler) {


### PR DESCRIPTION
This PR add support for managing the `disconnect` and `connect` events raised by the `EventSources` instance used for receiving notifications from the context broker using the ngsi-proxy.